### PR TITLE
add pipeline trigger concept + implement PubSub trigger

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,7 @@ Welcome to Flycs SDK's documentation!
    readme
    installation
    usage
+   triggers
    modules
    contributing
    authors

--- a/docs/triggers.rst
+++ b/docs/triggers.rst
@@ -1,0 +1,74 @@
+=================
+Pipeline triggers
+=================
+
+Flycs let you configure some triggers for your pipeline. A Trigger allow your pipeline to be triggered by an external event.
+The supported type of triggers are:
+
+- `PubSub topic`_
+
+PubSub topic
+############
+
+This triggers creates a subscription to the topic and then waits for any message to come. One a message is received, the rest of the pipeline is executed.
+
+The PubSub trigger has 2 property you can configure:
+
+- **topic**: The full path to a pubsub topic. The topic MUST exist before the pipeline with the trigger is executed.
+- **subscription_project**: Optional property that let you choose in which project the subscription to the topic will be created.
+
+Here is an example Pipeline definition using the PubSub trigger:
+
+.. code-block:: yaml
+
+    name: demo
+    kind: vanilla
+    version: 1.0.0
+    entities:
+    - name: demo
+        version: 1.0.0
+        stage_config:
+        - name: preamble
+            versions: {}
+        - name: staging
+            versions:
+            simple_copy: "1.0.0"
+        - name: datalake
+            versions:
+            simple_copy: "1.0.0"
+            history: "1.0.0"
+        - name: data_warehouse
+            versions:
+            simple_copy: "1.0.0"
+            manipulating_pii_fields: "1.0.0"
+        - name: data_mart
+            versions:
+            simple_copy: "1.0.0"
+            salary: "1.0.0"
+    start_time: "2021-01-01T00:00:00"
+    trigger:
+        type: "pubsub"
+        topic: "projects/my_project/topics/my_topic"
+        subscription_project: my_other_project
+
+The same pipeline defined using the Flycs SDK:
+
+.. code-block:: python
+
+    from datetime import datetime, timezone
+
+    from flycs_sdk.pipelines import Pipeline, PipelineKind
+    from flycs_sdk.triggers import PubSubTrigger
+    from .entities import entity # entities are define in another modules, we just import them here.
+
+    p = Pipeline(
+        name="demo",
+        version="1.0.0",
+        entities=[entity],
+        kind=PipelineKind.VANILLA,
+        start_time=datetime.now(tz=timezone.utc),
+        trigger=PubSubTrigger(topic="projects/my_project/topics/my_topic", subscription_project="my_other_project"),
+    )
+
+Note how the **schedule** property is not required on the pipeline definition when you specify a trigger.
+The reason for this is that Flycs will automatically configure your pipeline to be schedule every seconds so that it is always running and waiting on the trigger event to occur.

--- a/flycs_sdk/triggers.py
+++ b/flycs_sdk/triggers.py
@@ -1,0 +1,50 @@
+"""This module contains different type of Pipeline triggers."""
+
+
+from abc import ABC
+
+
+class PipelineTrigger(ABC):
+    """Base class for all pipeline trigger."""
+
+    pass
+
+
+class PubSubTrigger(PipelineTrigger):
+    """Class used to define a pipeline trigger using a PubSub topic."""
+
+    def __init__(self, topic: str, subscription_project: str = None):
+        """Create a new PubSubTrigger object.
+
+        :param topic: pubsub topic
+        :type topic: str
+        :param subscription_project: The project where to create the subscription, if not specified, the ops project will be used
+        :type subscription_project: str
+        """
+        self.topic = topic
+        self.subscription_project = subscription_project
+
+    @classmethod
+    def from_dict(cls, d: dict):
+        """Create a PubSubTrigger object form a dictionnary created with the to_dict method."""
+        return cls(topic=d["topic"], subscription_project=d.get("subscription_project"))
+
+    def to_dict(self):
+        """
+        Serialize the PubSubTrigger to a dictionary object.
+
+        :return: the PubSubTrigger as a dictionary object.
+        :rtype: Dict
+        """
+        return {
+            "type": "pubsub",
+            "topic": self.topic,
+            "subscription_project": self.subscription_project,
+        }
+
+    def __eq__(self, other) -> bool:
+        """Implement __eq__ method."""
+        return (
+            self.topic == other.topic
+            and self.subscription_project == other.subscription_project
+        )

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -15,11 +15,14 @@ from flycs_sdk.pipelines import (
     _format_datetime,
 )
 
+from flycs_sdk.triggers import PubSubTrigger
+
 pipeline_name = "test"
 pipeline_version = "1.0.0"
 pipeline_schedule = "* 12 * * *"
 pipeline_kind = PipelineKind.VANILLA
 pipeline_start_time = datetime.fromtimestamp(1606923514, tz=timezone.utc)
+pipeline_pubsub_topic = "my_topic"
 
 
 class TestPipeline:
@@ -42,6 +45,18 @@ class TestPipeline:
             entities=[],
         )
 
+    @pytest.fixture
+    def my_pipeline_pubsub(self, my_entity):
+        return Pipeline(
+            name=pipeline_name,
+            version=pipeline_version,
+            schedule=pipeline_schedule,
+            kind=pipeline_kind,
+            start_time=pipeline_start_time,
+            trigger=PubSubTrigger(pipeline_pubsub_topic),
+            entities=[],
+        )
+
     def test_init(self, my_pipeline):
         assert my_pipeline.name == pipeline_name
         assert my_pipeline.version == pipeline_version
@@ -50,9 +65,18 @@ class TestPipeline:
         assert my_pipeline.kind == pipeline_kind
         assert my_pipeline.entities == []
 
+    def test_init_pubsub(self, my_pipeline_pubsub):
+        assert my_pipeline_pubsub.name == pipeline_name
+        assert my_pipeline_pubsub.version == pipeline_version
+        assert my_pipeline_pubsub.schedule == pipeline_schedule
+        assert my_pipeline_pubsub.start_time == pipeline_start_time
+        assert my_pipeline_pubsub.kind == pipeline_kind
+        assert my_pipeline_pubsub.entities == []
+        assert my_pipeline_pubsub.trigger.topic == pipeline_pubsub_topic
+
     def test_invalid_start_time(self):
         with pytest.raises(TypeError):
-            return Pipeline(
+            Pipeline(
                 name=pipeline_name,
                 version=pipeline_version,
                 schedule=pipeline_schedule,
@@ -61,7 +85,7 @@ class TestPipeline:
                 entities=[],
             )
         with pytest.raises(ValueError):
-            return Pipeline(
+            Pipeline(
                 name=pipeline_name,
                 version=pipeline_version,
                 schedule=pipeline_schedule,
@@ -86,6 +110,41 @@ class TestPipeline:
             "schedule": pipeline_schedule,
             "kind": pipeline_kind.value,
             "start_time": "2020-12-02T15:38:34+0000",
+            "trigger": None,
+            "params": {},
+            "entities": [
+                {
+                    "name": "entity1",
+                    "version": "1.0.0",
+                    "stage_config": [
+                        {
+                            "name": "raw",
+                            "versions": {"table_1": "1.0.0", "table_2": "1.0.0"},
+                        },
+                        {
+                            "name": "staging",
+                            "versions": {"table_1": "1.0.0", "table_2": "1.0.0"},
+                        },
+                    ],
+                }
+            ],
+        }
+        assert expected == actual
+
+    def test_to_dict_pubsub(self, my_pipeline_pubsub, my_entity):
+        my_pipeline_pubsub.add_entity(my_entity)
+        actual = my_pipeline_pubsub.to_dict()
+        expected = {
+            "name": pipeline_name,
+            "version": pipeline_version,
+            "schedule": pipeline_schedule,
+            "kind": pipeline_kind.value,
+            "start_time": "2020-12-02T15:38:34+0000",
+            "trigger": {
+                "type": "pubsub",
+                "topic": "my_topic",
+                "subscription_project": None,
+            },
             "params": {},
             "entities": [
                 {
@@ -114,6 +173,16 @@ class TestPipeline:
         for d in serialized:
             loaded = Pipeline.from_dict(d)
             if isinstance(my_pipeline, ParametrizedPipeline):
+                assert loaded.params  # ensure the params area loaded
+
+    def test_serialize_deserialize(self, my_pipeline_pubsub, my_entity):
+        my_pipeline_pubsub.add_entity(my_entity)
+        serialized = my_pipeline_pubsub.to_dict()
+        if not isinstance(serialized, list):
+            serialized = [serialized]
+        for d in serialized:
+            loaded = Pipeline.from_dict(d)
+            if isinstance(my_pipeline_pubsub, ParametrizedPipeline):
                 assert loaded.params  # ensure the params area loaded
 
     def test_parse_datetime(self):
@@ -172,6 +241,7 @@ class TestParametrizedPipeline(TestPipeline):
                 "version": "1.0.0",
                 "schedule": "* 12 * * *",
                 "start_time": "2020-12-02T15:38:34+0000",
+                "trigger": None,
                 "kind": "vanilla",
                 "params": {"language": "nl", "country": "be"},
                 "entities": [
@@ -196,6 +266,7 @@ class TestParametrizedPipeline(TestPipeline):
                 "version": "1.0.0",
                 "schedule": "* 12 * * *",
                 "start_time": "2020-12-02T15:38:34+0000",
+                "trigger": None,
                 "kind": "vanilla",
                 "params": {"language": "nl", "country": "en"},
                 "entities": [
@@ -220,6 +291,7 @@ class TestParametrizedPipeline(TestPipeline):
                 "version": "1.0.0",
                 "schedule": "* 12 * * *",
                 "start_time": "2020-12-02T15:38:34+0000",
+                "trigger": None,
                 "kind": "vanilla",
                 "params": {"language": "fr", "country": "be"},
                 "entities": [
@@ -244,6 +316,7 @@ class TestParametrizedPipeline(TestPipeline):
                 "version": "1.0.0",
                 "schedule": "* 12 * * *",
                 "start_time": "2020-12-02T15:38:34+0000",
+                "trigger": None,
                 "kind": "vanilla",
                 "params": {"language": "fr", "country": "en"},
                 "entities": [


### PR DESCRIPTION
With this commit it is possible to define a "trigger" on a pipeline.
Depending on the type of trigger object passed to the pipeline, the
trigger method will be different.

This commit implement a PubSubTrigger which trigger a DAG when a message
is received on PubSub topic.